### PR TITLE
Add option to sort CSV by alphabetical over length.

### DIFF
--- a/csv_writer.go
+++ b/csv_writer.go
@@ -29,8 +29,9 @@ const (
 // CSVWriter writes CSV data.
 type CSVWriter struct {
 	*csv.Writer
-	HeaderStyle KeyStyle
-	Transpose   bool
+	HeaderStyle    KeyStyle
+	Transpose      bool
+	OrderByLexical bool
 }
 
 // NewCSVWriter returns new CSVWriter with JSONPointerStyle.
@@ -38,6 +39,7 @@ func NewCSVWriter(w io.Writer) *CSVWriter {
 	return &CSVWriter{
 		csv.NewWriter(w),
 		JSONPointerStyle,
+		false,
 		false,
 	}
 }
@@ -56,7 +58,11 @@ func (w *CSVWriter) writeCSV(results []KeyValue) error {
 	if err != nil {
 		return err
 	}
-	sort.Sort(pts)
+	if w.OrderByLexical {
+		sort.Sort(pointersByLexical(pts))
+	} else {
+		sort.Sort(pts)
+	}
 	keys := pts.Strings()
 	header := w.getHeader(pts)
 
@@ -85,7 +91,11 @@ func (w *CSVWriter) writeTransposedCSV(results []KeyValue) error {
 	if err != nil {
 		return err
 	}
-	sort.Sort(pts)
+	if w.OrderByLexical {
+		sort.Sort(pointersByLexical(pts))
+	} else {
+		sort.Sort(pts)
+	}
 	keys := pts.Strings()
 	header := w.getHeader(pts)
 

--- a/pointers.go
+++ b/pointers.go
@@ -25,6 +25,32 @@ func (pts pointers) Less(i, j int) bool {
 	return false
 }
 
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+type pointersByLexical pointers
+
+func (pts pointersByLexical) Len() int      { return len(pts) }
+func (pts pointersByLexical) Swap(i, j int) { pts[i], pts[j] = pts[j], pts[i] }
+func (pts pointersByLexical) Less(i, j int) bool {
+	// Compare each part
+	for n := 0; n < min(pts[i].Len(), pts[j].Len()); n++ {
+		if pts[i][n] != pts[j][n] {
+			return pts[i][n] < pts[j][n]
+		}
+	}
+
+	if pts[i].Len() != pts[j].Len() {
+		return pts[i].Len() < pts[j].Len()
+	}
+
+	return false
+}
+
 func (pts pointers) Strings() []string {
 	keys := make([]string, 0, pts.Len())
 	for _, p := range pts {


### PR DESCRIPTION
Currently the JSON CSV sorter sorts by length first then alphabetical. We would prefer strict alphabetical first.